### PR TITLE
[BUG] Fix incorrect option for param group in adagrad

### DIFF
--- a/csrc/embedding/adagrad.cc
+++ b/csrc/embedding/adagrad.cc
@@ -70,17 +70,17 @@ void SparseAdagrad::add_param_group(
     const SparseOptimizerParamGroup &param_group) {
   SparseOptimizerParamGroup param_group_(param_group.params());
   // set options for group
-  if (!param_group_.has_options()) {
+  if (!param_group.has_options()) {
     param_group_.set_options(defaults_->clone());
   } else {
-    param_group_.set_options(param_group_.options().clone());
+    param_group_.set_options(param_group.options().clone());
   }
   //  init optimizer global state for hashtable name <-> hashtable ptr
   for (const auto &param : param_group_.params()) {
     init_param_state(param.second, param_group_.options());
   }
   // add param group
-  param_groups_.emplace_back(param_group);
+  param_groups_.emplace_back(param_group_);
 }
 
 void SparseAdagrad::add_parameters(

--- a/recis/optim/__init__.py
+++ b/recis/optim/__init__.py
@@ -10,6 +10,7 @@ from recis.optim.named_optimizer import (
 from recis.optim.sparse_adam import SparseAdam as SparseAdam
 from recis.optim.sparse_adamw import SparseAdamW as SparseAdamW
 from recis.optim.sparse_adamw_tf import SparseAdamWTF as SparseAdamWTF
+from recis.optim.sparse_adagrad import SparseAdagrad as SparseAdagrad
 
 
 __all__ = [
@@ -22,5 +23,6 @@ __all__ = [
     "SparseAdam",
     "SparseAdamW",
     "SparseAdamWTF",
+    "SparseAdagrad",
     "wrapped_named_optimizer",
 ]


### PR DESCRIPTION
In `add_param_group` of adagrad, it mistakenly uses input parameter and local variable

1. when adding option, the input parameter `param_group` should be used instead of the local variable `param_group_`
2. the final emplace_back should use local `param_group_` instead of the input parameter `param_group`

Also the `SparseAdagrad` was not exposed for use.